### PR TITLE
Correction in WOWA computation + correction tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+.idea/
+java-aggregation.iml

--- a/src/main/java/info/debatty/java/aggregation/WOWA.java
+++ b/src/main/java/info/debatty/java/aggregation/WOWA.java
@@ -57,17 +57,17 @@ public class WOWA implements AggregatorInterface {
         int size = weights.size();
 
         Vector values_vector = new Vector(values);
-        values_vector.sort(weights);
+        values_vector.sort(ordered_weights);
 
         Vector omega = new Vector(size);
         InterpolationFunctions interpolations =
-                ordered_weights.getInterpolationFunctions();
-        omega.set(0, interpolations.eval(weights.get(0)));
+                weights.getInterpolationFunctions();
+        omega.set(0, interpolations.eval(ordered_weights.get(0)));
 
-        double acc = weights.get(0);
+        double acc = ordered_weights.get(0);
         for (int i = 2; i <= size; i++) {
             double temp = acc;
-            acc += weights.get(i - 1);
+            acc += ordered_weights.get(i - 1);
             omega.set(
                     i - 1,
                     interpolations.eval(acc) - interpolations.eval(temp));

--- a/src/test/java/info/debatty/java/aggregation/WOWATest.java
+++ b/src/test/java/info/debatty/java/aggregation/WOWATest.java
@@ -56,7 +56,9 @@ public class WOWATest extends TestCase {
         double[] ordered_weights = new double[] {0.0, 1.0, 0.0, 0.0, 0.0};
 
         WOWA wowa = new WOWA(weights, ordered_weights);
-        double exp = 0.3;
+        //double exp = 0.3;
+        //Value checked with php-aggregation package
+        double exp = 0.2;
         double result = wowa.aggregate(values);
         assertEquals(exp, result, 1E-9);
     }
@@ -69,7 +71,9 @@ public class WOWATest extends TestCase {
         double[] weights = new double[] {0.0, 1.0, 0.0, 0.0, 0.0};
 
         WOWA wowa = new WOWA(weights, ordered_weights);
-        double exp = 0.2;
+        //double exp = 0.2;
+        //Value checked thanks to php-aggregation
+        double exp = 0.3;
         double result = wowa.aggregate(values);
         assertEquals(exp, result, 1E-9);
     }


### PR DESCRIPTION
There was an inversion between weight and ordered_weight in the aggregation function. Some results were identical to php-aggregation because it was very specific examples.

