### PR TITLE
Correction to avoid overflow and NaN result

### DIFF
--- a/src/main/java/info/debatty/java/aggregation/InterpolationFunctions.java
+++ b/src/main/java/info/debatty/java/aggregation/InterpolationFunctions.java
@@ -30,6 +30,8 @@ package info.debatty.java.aggregation;
  */
 class InterpolationFunctions {
 
+    // This will in some cases be multiplied by 2, hence we use a smaller
+    // value to avoid overflow
     private static final double INFINITY = 10E100;
 
     private final Point[] points;

--- a/src/main/java/info/debatty/java/aggregation/InterpolationFunctions.java
+++ b/src/main/java/info/debatty/java/aggregation/InterpolationFunctions.java
@@ -30,7 +30,7 @@ package info.debatty.java.aggregation;
  */
 class InterpolationFunctions {
 
-    private static final double INFINITY = Double.MAX_VALUE;
+    private static final double INFINITY = 10E100;
 
     private final Point[] points;
     private final InterpolationFunction[] functions;


### PR DESCRIPTION
Double.MAX_VALUE is multiply by a number (maximum 2) and trigs an overflow. The value becomes Infinity and later, Infinity - Infinity generates a NaN result.

Value replace by a smaller one but big enough for the computation. 