### PR TITLE
Add Exception management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,8 +111,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
 
@@ -151,10 +151,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 </project>

--- a/src/main/java/info/debatty/java/aggregation/OWA.java
+++ b/src/main/java/info/debatty/java/aggregation/OWA.java
@@ -37,7 +37,10 @@ public class OWA implements AggregatorInterface {
      * Initialize with provided weights.
      * @param weights
      */
-    public OWA(final double[] weights) {
+    public OWA(final double[] weights)  {
+        if (arraySum(weights) != 1.0) {
+            throw new IllegalArgumentException("Sum of weights must be equal to 1");
+        }
         this.weights = new Vector(weights);
     }
 
@@ -46,5 +49,19 @@ public class OWA implements AggregatorInterface {
 
         Vector values_vector = new Vector(values);
         return values_vector.sort().dotProduct(weights);
+    }
+
+    /**
+     * Method to sum the elements in an double array.
+     * Used to check if the sum of vector's elements is equal to 1.0.
+     * @param values
+     * @return
+     */
+    protected final double arraySum(final double[] values) {
+        double sum = 0.0;
+        for (double el : values) {
+            sum = sum + el;
+        }
+        return sum;
     }
 }

--- a/src/main/java/info/debatty/java/aggregation/WOWA.java
+++ b/src/main/java/info/debatty/java/aggregation/WOWA.java
@@ -56,6 +56,9 @@ public class WOWA implements AggregatorInterface {
                 throw new IllegalArgumentException("Weights must be between 0 and 1");
             }
         }
+        if (arraySum(weights) != 1.0 || arraySum(ordered_weights) != 1.0) {
+            throw new IllegalArgumentException("Sum of a weights vector must be equal to 1");
+        }
         this.weights = new Vector(weights);
         this.ordered_weights = new Vector(ordered_weights);
     }
@@ -90,5 +93,19 @@ public class WOWA implements AggregatorInterface {
         }
 
         return values_vector.dotProduct(omega);
+    }
+
+    /**
+     * Method to sum the elements in an double array.
+     * Used to check if the sum of vector's elements is equal to 1.0.
+     * @param values
+     * @return
+     */
+    protected final double arraySum(final double[] values) {
+        double sum = 0.0;
+        for (double el : values) {
+            sum = sum + el;
+        }
+        return sum;
     }
 }

--- a/src/test/java/info/debatty/java/aggregation/OWATest.java
+++ b/src/test/java/info/debatty/java/aggregation/OWATest.java
@@ -24,17 +24,19 @@
 
 package info.debatty.java.aggregation;
 
-import junit.framework.TestCase;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
  * @author Thibault Debatty
  */
-public class OWATest extends TestCase {
+public class OWATest {
 
-    public OWATest(String testName) {
-        super(testName);
-    }
+    private OWA owa;
 
     /**
      * Test of aggregate method, of class OWA.
@@ -49,6 +51,22 @@ public class OWATest extends TestCase {
         double expResult = 0.2;
         double result = instance.aggregate(values);
         assertEquals(expResult, result, 0.0);
+    }
+    /**
+     * Test if Exception is triggered during the construction.
+     * If the vector has a sum different from 1.0.
+     */
+    @Test
+    public void testIllegalArgumentExceptionThrown() {
+        final double[] values3 = {0.1, 0.6, 0.2, 0.4};
+        assertThrows(IllegalArgumentException.class, () -> {
+            new OWA(values3);
+        });
+
+        final double[] values4 = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        assertThrows(IllegalArgumentException.class, () -> {
+            new OWA(values4);
+        });
     }
 
 }

--- a/src/test/java/info/debatty/java/aggregation/OWATest.java
+++ b/src/test/java/info/debatty/java/aggregation/OWATest.java
@@ -50,7 +50,7 @@ public class OWATest {
         OWA instance = new OWA(weights);
         double expResult = 0.2;
         double result = instance.aggregate(values);
-        assertEquals(expResult, result, 0.0);
+        assertEquals(expResult, result);
     }
     /**
      * Test if Exception is triggered during the construction.

--- a/src/test/java/info/debatty/java/aggregation/WOWATest.java
+++ b/src/test/java/info/debatty/java/aggregation/WOWATest.java
@@ -24,20 +24,23 @@
 
 package info.debatty.java.aggregation;
 
-import junit.framework.TestCase;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
  * @author Thibault Debatty
  */
-public class WOWATest extends TestCase {
+public class WOWATest {
 
     /**
      * Test of aggregate method, of class WOWA.
      */
+    @Test
     public void testAggregate() {
-        System.out.println("WOWA");
-
         double[] values = new double[] {0.4, 0.2, 0.3, 0.1, 0.0};
         double[] weights = new double[] {0.1, 0.2, 0.3, 0.4, 0.0};
         double[] ordered_weights = new double[] {0.1, 0.2, 0.3, 0.4, 0.0};
@@ -47,10 +50,8 @@ public class WOWATest extends TestCase {
         double result = wowa.aggregate(values);
         assertEquals(exp, result, 1E-9);
     }
-
+    @Test
     public void testAggregate2() {
-        System.out.println("WOWA2");
-
         double[] values = new double[] {0.4, 0.2, 0.3, 0.1, 0.0};
         double[] weights = new double[] {0.2, 0.2, 0.2, 0.2, 0.2};
         double[] ordered_weights = new double[] {0.0, 1.0, 0.0, 0.0, 0.0};
@@ -62,10 +63,8 @@ public class WOWATest extends TestCase {
         double result = wowa.aggregate(values);
         assertEquals(exp, result, 1E-9);
     }
-
+    @Test
     public void testAggregate3() {
-        System.out.println("WOWA3");
-
         double[] values = new double[] {0.4, 0.2, 0.3, 0.1, 0.0};
         double[] ordered_weights = new double[] {0.2, 0.2, 0.2, 0.2, 0.2};
         double[] weights = new double[] {0.0, 1.0, 0.0, 0.0, 0.0};
@@ -76,6 +75,31 @@ public class WOWATest extends TestCase {
         double exp = 0.3;
         double result = wowa.aggregate(values);
         assertEquals(exp, result, 1E-9);
+    }
+
+    /**
+     * Test if Exception is triggered during the construction.
+     * If at least one vector has a sum different from 1.0.
+     */
+    @Test
+    public void testIllegalArgumentExceptionThrown() {
+        final double[] values3 = {0.1, 0.6, 0.2, 0.4};
+        final double[] values4 = {0.2, 0.5, 0.2, 0.1};
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WOWA(values3, values4);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WOWA(values4, values3);
+        });
+
+        final double[] values5 = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        final double[] values6 = {0.2, 0.3, 0.5, 0.3, 0.4, 0.4, 0.1};
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WOWA(values5, values6);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WOWA(values6, values5);
+        });
     }
 
 }


### PR DESCRIPTION
Exceptions added for the sum of vector's elements not equal to 1.0. In OWA and WOWA.
New tests to verify these modifications.
To test the Exceptions, I had to modify the pom.xml file. Use junit-jupiter-api instead of junit to ba able to use the method *assertThrows*